### PR TITLE
Fixing naming convention and leaving only one spoke per hub

### DIFF
--- a/.github/workflows/infra-anycast.yml
+++ b/.github/workflows/infra-anycast.yml
@@ -62,6 +62,7 @@ jobs:
 
     - name: Terraform Apply
       if: github.ref == 'refs/heads/main'
+      if: github.event_name != 'pull_request'
       uses: hashicorp/terraform-github-actions@master
       with:
         tf_actions_version: 0.14.8

--- a/.github/workflows/infra-anycast.yml
+++ b/.github/workflows/infra-anycast.yml
@@ -62,7 +62,6 @@ jobs:
 
     - name: Terraform Apply
       if: github.ref == 'refs/heads/main'
-      if: github.event_name != 'pull_request'
       uses: hashicorp/terraform-github-actions@master
       with:
         tf_actions_version: 0.14.8

--- a/infra-anycast/main.tf
+++ b/infra-anycast/main.tf
@@ -28,7 +28,7 @@ module "hub" {
   source          = "./modules/hub"
   prefix          = "${var.prefix}-eus-hub"
   location        = "eastus"
-  ip_second_octet = "200"
+  ip_second_octet = "222"
 }
 
 #################################
@@ -38,7 +38,7 @@ module "spoke_weu" {
   source          = "./modules/spoke"
   prefix          = "${var.prefix}-eus-s1"
   location        = "eastus"
-  ip_second_octet = "210"
+  ip_second_octet = "223"
   hub_vnet_name   = module.hub.hub_vnet_name
   hub_vnet_id     = module.hub.hub_vnet_id
   hub_rg_name     = module.hub.hub_rg_name
@@ -57,7 +57,7 @@ module "hub_weu" {
   source          = "./modules/hub"
   prefix          = "${var.prefix}-weu-hub"
   location        = "westeurope"
-  ip_second_octet = "100"
+  ip_second_octet = "111"
 
 }
 
@@ -68,7 +68,7 @@ module "spoke_weu_s1" {
   source                  = "./modules/spoke"
   prefix                  = "${var.prefix}-weu-s1"
   location                = "westeurope"
-  ip_second_octet         = "110"
+  ip_second_octet         = "112"
   hub_vnet_name           = module.hub_weu.hub_vnet_name
   hub_vnet_id             = module.hub_weu.hub_vnet_id
   hub_rg_name             = module.hub_weu.hub_rg_name

--- a/infra-anycast/main.tf
+++ b/infra-anycast/main.tf
@@ -26,7 +26,7 @@ variable "prefix" {
 #################################
 module "hub" {
   source          = "./modules/hub"
-  prefix          = "${var.prefix}-hub"
+  prefix          = "${var.prefix}-eus-hub"
   location        = "eastus"
   ip_second_octet = "200"
 }
@@ -36,7 +36,7 @@ module "hub" {
 #################################
 module "spoke_weu" {
   source          = "./modules/spoke"
-  prefix          = "${var.prefix}-weu"
+  prefix          = "${var.prefix}-eus-s1"
   location        = "eastus"
   ip_second_octet = "210"
   hub_vnet_name   = module.hub.hub_vnet_name
@@ -49,24 +49,9 @@ module "spoke_weu" {
   ]
 }
 
-module "spoke_eus" {
-  source          = "./modules/spoke"
-  prefix          = "${var.prefix}-eus"
-  location        = "eastus"
-  ip_second_octet = "220"
-  hub_vnet_name   = module.hub.hub_vnet_name
-  hub_vnet_id     = module.hub.hub_vnet_id
-  hub_rg_name     = module.hub.hub_rg_name
-  fw_vip          = module.hub.fw_vip
-
-  depends_on = [
-    module.hub
-  ]
-}
-
 
 #################################
-#           Hub2
+#           Hub-WEU
 #################################
 module "hub_weu" {
   source          = "./modules/hub"
@@ -77,7 +62,7 @@ module "hub_weu" {
 }
 
 #################################
-#           Spoke2
+#           Spokes-WEU
 #################################
 module "spoke_weu_s1" {
   source                  = "./modules/spoke"
@@ -95,24 +80,6 @@ module "spoke_weu_s1" {
     module.hub_weu
   ]
 }
-
-module "spoke_weu_s2" {
-  source                  = "./modules/spoke"
-  prefix                  = "${var.prefix}-weu-s2"
-  location                = "westeurope"
-  ip_second_octet         = "120"
-  hub_vnet_name           = module.hub_weu.hub_vnet_name
-  hub_vnet_id             = module.hub_weu.hub_vnet_id
-  hub_rg_name             = module.hub_weu.hub_rg_name
-  aks_network_plugin_mode = null
-  aks_ebpf_data_plane     = null
-  fw_vip                  = module.hub_weu.fw_vip
-
-  depends_on = [
-    module.hub_weu
-  ]
-}
-
 
 #################################
 #           Hub Peerings


### PR DESCRIPTION
New naming is:

crgar-glb-weu-hub
crgar-glb-weu-s1

crgar-glb-eus-hub
crgar-glb-eus-s1